### PR TITLE
Fix some event listener that were playing only once

### DIFF
--- a/dist/public/js/form/handleForm.js
+++ b/dist/public/js/form/handleForm.js
@@ -18,7 +18,7 @@ const playMusic = async (button, tablature) => {
         }
         const parsedMusic = parse(musicToPlay);
         if (parsedMusic.length < 10) {
-            button.textContent = 'Play it !';
+            button.textContent = 'Play it!';
             button.addEventListener('click', playMusicListener, { once: true });
             return addFormError(tablature);
         }
@@ -29,14 +29,14 @@ const playMusic = async (button, tablature) => {
             }
         }
         if (playerResult.hasFinishedPlaying && !playerResult.hasErrors) {
-            button.textContent = 'Play it !';
+            button.textContent = 'Play it!';
             button.addEventListener('click', () => playMusicListener, { once: true });
         }
     }
 };
 const stopMusic = (button, playMusicListener) => {
     Player.stop();
-    button.textContent = 'Play it !';
+    button.textContent = 'Play it!';
     button.addEventListener('click', playMusicListener, { once: true });
 };
 const parseAsJson = (notes) => {

--- a/dist/public/js/presetSongs/PresetSong.js
+++ b/dist/public/js/presetSongs/PresetSong.js
@@ -25,7 +25,7 @@ export default class PresetSong {
         const button = document.createElement('button');
         button.textContent = 'Play this song';
         button.classList.add('card-button');
-        card.addEventListener('click', () => this.playAction(button, card), { once: true });
+        card.addEventListener('click', () => this.playAction(button, card));
         contentContainer.appendChild(button);
         return card;
     }

--- a/dist/src/player/Player.js
+++ b/dist/src/player/Player.js
@@ -16,7 +16,7 @@ class Player {
         await this.#playNote(new Note('---').keys);
         for (const note of notes) {
             if (!this.#isPlaying) {
-                return new PlayerResult();
+                return new PlayerResult(false, true);
             }
             try {
                 await this.#playNote(note.keys);

--- a/public/js/form/handleForm.ts
+++ b/public/js/form/handleForm.ts
@@ -28,7 +28,7 @@ const playMusic = async (button: HTMLButtonElement, tablature: HTMLTextAreaEleme
 
 		// Prevent a few weird bugs where the parser would return some broken notes
 		if (parsedMusic.length < 10) {
-			button.textContent = 'Play it !';
+			button.textContent = 'Play it!';
 			button.addEventListener('click', playMusicListener, {once: true});
 
 			return addFormError(tablature);
@@ -43,7 +43,7 @@ const playMusic = async (button: HTMLButtonElement, tablature: HTMLTextAreaEleme
 		}
 
 		if (playerResult.hasFinishedPlaying && !playerResult.hasErrors) {
-			button.textContent = 'Play it !';
+			button.textContent = 'Play it!';
 			button.addEventListener('click', () => playMusicListener, {once: true});
 		}
 	}
@@ -52,7 +52,7 @@ const playMusic = async (button: HTMLButtonElement, tablature: HTMLTextAreaEleme
 const stopMusic = (button: HTMLButtonElement, playMusicListener: EventListener) => {
 	Player.stop();
 
-	button.textContent = 'Play it !';
+	button.textContent = 'Play it!';
 	button.addEventListener('click', playMusicListener, {once: true});
 };
 

--- a/public/js/presetSongs/PresetSong.ts
+++ b/public/js/presetSongs/PresetSong.ts
@@ -34,7 +34,7 @@ export default class PresetSong {
 		const button = document.createElement('button');
 		button.textContent = 'Play this song';
 		button.classList.add('card-button');
-		card.addEventListener('click', () => this.playAction(button, card), {once: true});
+		card.addEventListener('click', () => this.playAction(button, card));
 		contentContainer.appendChild(button);
 
 		return card;

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -26,7 +26,7 @@ class Player {
 
 		for (const note of notes) {
 			if (!this.#isPlaying) {
-				return new PlayerResult();
+				return new PlayerResult(false, true);
 			}
 
 			try {


### PR DESCRIPTION
Fix a bug where the inital events on the preset songs would only play once. If someone tried to click a preset song while another song is playing, it would therefore not play anything and definitely remove the event listener, making this button unusuable.

Also : 
- Remove spaces between text and '!'
- Makes the player return a PlayerResult with `hasFinishedPlaying` to true when we prematurely stop it