### PR TITLE
Change website URL in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is a small demo website that plays music with the Javascript Web Audio API.
 It simply aims at giving an idea of what you can do with the API. You may find it at the following address :
 
-https://hedicguibert.github.io/web-audio-api-demo/
+https://jolicode.github.io/web-audio-api-demo/
 
 This website will parse tablatures taken from https://pianoletternotes.blogspot.com/ and play them in your browser.
 If you want to get the notes of the songs, you may get them as JSON. An article is being written on how to use these notes.


### PR DESCRIPTION
The repository was transferred to JoliCode, and since the website is hosted on GitHub Pages its URL had changed.